### PR TITLE
Make Vartheme BS5 Components the Default and Remove Varbase Components

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -2,13 +2,9 @@
 const config = {
   // Change the place where storybook searched for stories.
   stories: [
-    // Listing Varbase Components in the Storybook
-    "../docroot/modules/contrib/varbase_components/components/**/*.mdx",
-    "../docroot/modules/contrib/varbase_components/components/**/*.stories.@(json|yml)",
-    // -------------------------------------------------------------------------------
-    // Uncomment the following line to start listing components Vartheme BS5 Starterkit.
-    // "../docroot/themes/contrib/vartheme_ba5/components/**/*.mdx",
-    // "../docroot/themes/contrib/vartheme_ba5/components/**/*.stories.@(json|yml)",
+    // Listing Vartheme BS5 Starterkit components in the Storybook
+    "../docroot/themes/contrib/vartheme_ba5/components/**/*.mdx",
+    "../docroot/themes/contrib/vartheme_ba5/components/**/*.stories.@(json|yml)",
     // -------------------------------------------------------------------------------
     // Uncomment the following line to start listing components from custom cloned generated theme
     // Change `mytheme` to the name of the custom theme.

--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -3,8 +3,8 @@ const config = {
   // Change the place where storybook searched for stories.
   stories: [
     // Listing Vartheme BS5 Starterkit components in the Storybook
-    "../docroot/themes/contrib/vartheme_ba5/components/**/*.mdx",
-    "../docroot/themes/contrib/vartheme_ba5/components/**/*.stories.@(json|yml)",
+    "../docroot/themes/contrib/vartheme_bs5/components/**/*.mdx",
+    "../docroot/themes/contrib/vartheme_bs5/components/**/*.stories.@(json|yml)",
     // -------------------------------------------------------------------------------
     // Uncomment the following line to start listing components from custom cloned generated theme
     // Change `mytheme` to the name of the custom theme.


### PR DESCRIPTION

## Description
Please describe your changes in detail according to the information below

## Related Issue
This project only accepts pull requests related to open issues.
- If suggesting a new feature or change, please discuss it in an issue first
- If fixing a bug, there should be an issue describing it with steps to reproduce it following the bug report guide
- If you're suggesting a feature, please follow the feature request guide by clicking on issues

### Please drop a link to the issue here:

## Motivation and Context
Why is this change required? What problem does it solve?

## How Has This Been Tested?
Please describe in detail how you tested your changes. Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc.

## Screenshots (if appropriate):

## Types of changes
What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
 Go over all the following list, and put an `x` in all the boxes that apply. If you're unsure about what any of these mean, don't hesitate to ask. We're here to help!

- [ ] I have read the contribution guide
- [ ] I have created an issue following the issue guide
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
